### PR TITLE
Fix libxml2 2.9.4 regression

### DIFF
--- a/xmlschemas.c
+++ b/xmlschemas.c
@@ -27396,17 +27396,10 @@ xmlSchemaSAXHandleStartElementNs(void *ctx,
 
         for (j = 0, i = 0; i < nb_attributes; i++, j += 5) {
 	    /*
-	    * Duplicate the value, changing any &#38; to a literal ampersand.
-	    *
-	    * libxml2 differs from normal SAX here in that it escapes all ampersands
-	    * as &#38; instead of delivering the raw converted string. Changing the
-	    * behavior at this point would break applications that use this API, so
-	    * we are forced to work around it. There is no danger of accidentally
-	    * decoding some entity other than &#38; in this step because without
-	    * unescaped ampersands there can be no other entities in the string.
+	    * Duplicate the value.
 	    */
-	    value = xmlStringLenDecodeEntities(vctxt->parserCtxt, attributes[j+3],
-		attributes[j+4] - attributes[j+3], XML_SUBSTITUTE_REF, 0, 0, 0);
+	    value = xmlStrndup(attributes[j+3],
+		    attributes[j+4] - attributes[j+3]);
 	    /*
 	    * TODO: Set the node line.
 	    */


### PR DESCRIPTION
libxml2 2.9.4 introduced a regression regarding XSD validation. Apparently,
all constraints for attributes fail due to this bug, which has been reported
as https://bugzilla.gnome.org/show_bug.cgi?id=766834.

Wrt. PHP at least XMLReader::setSchema() is affected, what has been reported
as https://bugs.php.net/bug.php?id=73053.

We fix this regression by simply reverting the faulty commit
https://git.gnome.org/browse/libxml2/commit/?id=f6599c51648 for now.
