### PR TITLE
Apply the security patch for v2.10.x

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -7155,6 +7155,14 @@ xmlParseReference(xmlParserCtxtPtr ctxt) {
     }
 
     /*
+     * Some users try to parse entities on their own and used to set
+     * the renamed "checked" member. Fix the flags to cover this
+     * case.
+     */
+    if (((ent->flags & XML_ENT_PARSED) == 0) && (ent->children != NULL))
+        ent->flags |= XML_ENT_PARSED;
+
+    /*
      * The first reference to the entity trigger a parsing phase
      * where the ent->children is filled with the result from
      * the parsing.


### PR DESCRIPTION
@nielsdos @cmb69 

I found the patch that needs to be backported to the v2.10.x branch. (Related: #9 )
Would you please review this PR if you have time?

This PR includes the following security patch for v2.10.x branch.
- CVE-2024-40896 : https://gitlab.gnome.org/GNOME/libxml2/-/commit/1a8932303969907f6572b1b6aac4081c56adb5c6.patch


Related Issue:
[CVE-2024-40896] XXE protection broken in downstream code
https://gitlab.gnome.org/GNOME/libxml2/-/issues/761

Thank you.